### PR TITLE
refactor: Remove dynamic rendering export from multiple API routes

### DIFF
--- a/app/api/chat-csv/route.ts
+++ b/app/api/chat-csv/route.ts
@@ -1,8 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
-export const dynamic = 'force-dynamic';
-
 export async function POST(request: NextRequest) {
   try {
     const { message, fileId, tableName, messages } = await request.json();

--- a/app/api/delete-kpi-metric/route.ts
+++ b/app/api/delete-kpi-metric/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
 
-export const dynamic = 'force-dynamic';
 
 export async function DELETE(request: NextRequest) {
   try {

--- a/app/api/generate-kpi-analysis/route.ts
+++ b/app/api/generate-kpi-analysis/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import OpenAI from "openai";
 import { OpenAIKPIAnalysis } from "@/types/kpi";
 
-export const dynamic = 'force-dynamic';
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 

--- a/app/api/generate-summary/route.ts
+++ b/app/api/generate-summary/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import OpenAI from "openai";
 
-export const dynamic = 'force-dynamic';
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 

--- a/app/api/get-csv-data/route.ts
+++ b/app/api/get-csv-data/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
 
-export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/get-kpi-analysis/route.ts
+++ b/app/api/get-kpi-analysis/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
-export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/get-projects/route.ts
+++ b/app/api/get-projects/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { TableauAuth, TableauCredentials } from '@/lib/tableau-auth';
 import axios from 'axios';
 
-export const dynamic = 'force-dynamic';
 
 export async function GET() {
   try {

--- a/app/api/publish-datasource/route.ts
+++ b/app/api/publish-datasource/route.ts
@@ -12,7 +12,6 @@ import {
   generateObjectId 
 } from '@/lib/uuid-utils';
 
-export const dynamic = 'force-dynamic';
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/publish-workbook/route.ts
+++ b/app/api/publish-workbook/route.ts
@@ -5,7 +5,6 @@ import { TABLEAU_SETTINGS, ALLOWED_EXTENSIONS, DEFAULT_NAMES } from '@/lib/confi
 import { generateWorkbookName } from '@/lib/uuid-utils';
 import fs from 'fs';
 
-export const dynamic = 'force-dynamic';
 
 export async function POST(request: NextRequest) {
   try {


### PR DESCRIPTION
- Removed `export const dynamic = 'force-dynamic';` from several API route files to streamline the codebase and revert to default rendering behavior.
- This change simplifies the API routes while maintaining their core functionality.